### PR TITLE
Fix incorrect right-alignment of UTF-8 text in table cells (#2)

### DIFF
--- a/examples/16_table_utf8_alignment.php
+++ b/examples/16_table_utf8_alignment.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Example 16: Right-aligned table cells with UTF-8 text (GitHub issue #2)
+ *
+ * Reproduces the reported problem: in a right-aligned column, values containing
+ * the "€" glyph, a non-breaking space (as inserted by NumberFormatter) or a
+ * minus sign were pushed left — they gained extra right-hand padding — because
+ * cell width was estimated from the raw UTF-8 byte length (a 3-byte "€" counted
+ * as three glyphs) using a flat per-character average, while the text is in fact
+ * rendered after a UTF-8 → Windows-1252 conversion.
+ *
+ * The fix makes width measurement use the embedded font's real glyph advance
+ * widths, applied to the exact Windows-1252 bytes that are drawn. This example
+ * renders the offending layout and prints a numeric before/after comparison so
+ * the correction is visible without opening the PDF.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Papier\PdfDocument;
+use Papier\Elements\{Color, Table, TableCell, Text};
+use Papier\Font\TrueTypeFont;
+
+$fontPath = __DIR__ . '/Lato-Regular.ttf';
+
+// 1 mm in points (the issue's helper pt()): 1 mm = 72 / 25.4 pt.
+$mm = static fn (float $v): float => $v * 72.0 / 25.4;
+
+// Format currency the way the issue does (de_DE → "1.234,56 €" with a NBSP).
+// Fall back to a hand-built equivalent if the intl extension is unavailable.
+if (class_exists(\NumberFormatter::class)) {
+    $fmt = new \NumberFormatter('de_DE', \NumberFormatter::CURRENCY);
+    $euro = static fn (float $v): string => $fmt->formatCurrency($v, 'EUR');
+} else {
+    $euro = static function (float $v): string {
+        $s = number_format(abs($v), 2, ',', '.');
+        return ($v < 0 ? '-' : '') . $s . "\u{00A0}€"; // NBSP + euro sign
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Build the PDF
+// ─────────────────────────────────────────────────────────────────────────────
+$doc  = PdfDocument::create();
+$doc->setTitle('Issue #2 — right-aligned UTF-8 cells');
+
+$regular = $doc->addFont($fontPath);
+$page    = $doc->addPage();
+
+$page->add(
+    Text::write('Issue #2 — right-aligned UTF-8 table cells')
+        ->at($mm(25), 800)->font($regular, 13)->color(Color::rgb(0.12, 0.22, 0.42)),
+    Text::write('Every value in the three numeric columns must share the same right edge (~1 mm padding).')
+        ->at($mm(25), 786)->font($regular, 9)->color(Color::gray(0.35)),
+);
+
+// 4-column layout mirroring the report: label + three right-aligned amounts.
+$table = Table::create($mm(25), 770)
+    ->setColumnWidths($mm(80), $mm(30), $mm(30), $mm(30))
+    ->setFont($regular, 9, 'Lato-Regular')
+    ->setHeaderRows(1)
+    ->setHeaderBg(Color::rgb(0.12, 0.22, 0.42))
+    ->setHeaderTextColor(Color::white())
+    ->setBorder(Color::gray(0.4), 0.5)
+    ->setInnerBorder(Color::gray(0.8), 0.3)
+    ->setCellPadding(1)
+    ->setTextAlign('right');
+
+$table->addRow([
+    TableCell::make('Position')->align('left'),
+    'Net', 'VAT', 'Gross',
+]);
+
+$rows = [
+    ['Consulting (UTF-8: café, naïve)', 1234.56,  234.57, 1469.13],
+    ['Discount',                        -89.90,   -17.08,  -106.98],
+    ['Hosting €/month',                  12.00,     2.28,    14.28],
+    ['Large amount',                     98765.40, 18765.43, 117530.83],
+];
+foreach ($rows as $r) {
+    $table->addRow([
+        TableCell::make($r[0])->align('left'),
+        $euro($r[1]),
+        $euro($r[2]),
+        $euro($r[3]),
+    ]);
+}
+
+// Bold total row (the report noted bold also drifted).
+$total = array_sum(array_column($rows, 3));
+$table->addRow([
+    TableCell::make('Total')->align('left'),
+    '', '',
+    TableCell::make($euro($total)),
+]);
+
+$page->add($table);
+
+$doc->save(__DIR__ . '/output/16_table_utf8_alignment.pdf');
+echo "Created: 16_table_utf8_alignment.pdf\n";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Numeric sanity check — demonstrate the measurement fix
+// ─────────────────────────────────────────────────────────────────────────────
+$font   = TrueTypeFont::fromFile($fontPath);
+$size   = 9.0;
+$sample = $euro(1234.56); // e.g. "1.234,56 €"
+
+// Correct measurement: real glyph advances over the rendered (Windows-1252) bytes.
+$correct = $font->stringWidth($sample, $size);
+
+// Old behaviour: flat 0.55 em per raw UTF-8 byte (multi-byte "€"/NBSP over-counted).
+$oldEstimate = strlen($sample) * $size * 0.55;
+
+printf("\nMeasurement of %s at %.0f pt:\n", json_encode($sample), $size);
+printf("  old strlen×0.55 heuristic : %6.2f pt  (UTF-8 bytes = %d)\n", $oldEstimate, strlen($sample));
+printf("  new real-metric width     : %6.2f pt  (rendered glyphs = %d)\n",
+    $correct, strlen(\Papier\Font\Encoding\WinAnsiEncoding::fromUtf8($sample)));
+printf("  over-estimate removed     : %6.2f pt  → right-edge padding error eliminated\n",
+    $oldEstimate - $correct);

--- a/src/Content/ContentStream.php
+++ b/src/Content/ContentStream.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Papier\Content;
 
+use Papier\Font\Encoding\WinAnsiEncoding;
+
 /**
  * PDF content stream builder (ISO 32000-1 §7.8.2, §8, §9).
  *
@@ -727,7 +729,9 @@ final class ContentStream
     private function pdfString(string $s): string
     {
         // Convert UTF-8 → Windows-1252 so Latin accented characters render correctly.
-        $s = mb_convert_encoding($s, 'Windows-1252', 'UTF-8');
+        // Same conversion drives width measurement (Font::stringWidth), so the bytes
+        // measured for alignment match the bytes drawn here.
+        $s = WinAnsiEncoding::fromUtf8($s);
 
         $escaped = '';
         $len     = strlen($s);

--- a/src/Elements/Table.php
+++ b/src/Elements/Table.php
@@ -103,6 +103,14 @@ final class Table implements Element
     private string $textAlign    = 'left';
     private string $valign       = 'top';
 
+    /**
+     * Resources for the current render() pass, used to resolve font resource
+     * names to {@see \Papier\Font\Font} metrics objects for accurate text
+     * measurement.  Set at the top of render(); null when measuring outside a
+     * render (falls back to heuristic metrics).
+     */
+    private ?PdfResources $renderResources = null;
+
     // ── Header style ──────────────────────────────────────────────────────────
 
     private int    $headerRows      = 0;
@@ -547,6 +555,8 @@ final class Table implements Element
             return;
         }
 
+        $this->renderResources = $resources;
+
         $numCols = $this->computeColumnCount();
         $colW    = $this->resolveColumnWidths($numCols);
 
@@ -724,7 +734,7 @@ final class Table implements Element
         [$pT, $pR, $pB, $pL]          = $this->resolveCellPadding($cell);
         $cellW  = $this->spanWidth($colW, $cell->gridCol, $cell->colspan);
         $innerW = $cellW - $pL - $pR;
-        $lines  = $this->wrapText($cell->text, max(1, $innerW), $fBase, $fSize);
+        $lines  = $this->wrapText($cell->text, max(1, $innerW), $fName, $fBase, $fSize);
         $leading = $fSize * $lh;
         return $pT + count($lines) * $leading + $pB;
     }
@@ -925,7 +935,7 @@ final class Table implements Element
 
         $innerW  = max(1, $cw - $pL - $pR);
         $leading = $fSize * $lhMul;
-        $lines   = $this->wrapText($cell->text, $innerW, $fBase, $fSize);
+        $lines   = $this->wrapText($cell->text, $innerW, $fName, $fBase, $fSize);
 
         // Vertical alignment: compute Y of first baseline
         $nLines      = count($lines);
@@ -957,7 +967,7 @@ final class Table implements Element
             }
             $tx = $cx + $pL;
             if ($align !== 'left' && $line !== '') {
-                $lineW = $this->measureWidth($line, $fBase, $fSize);
+                $lineW = $this->measureWidth($line, $fName, $fBase, $fSize);
                 $tx   += match ($align) {
                     'right'  => $innerW - $lineW,
                     'center' => ($innerW - $lineW) / 2.0,
@@ -1104,7 +1114,7 @@ final class Table implements Element
     /**
      * @return string[]
      */
-    private function wrapText(string $text, float $maxWidth, string $baseFontName, float $size): array
+    private function wrapText(string $text, float $maxWidth, string $fontName, string $baseFontName, float $size): array
     {
         $lines = [];
         foreach (explode("\n", $text) as $para) {
@@ -1116,7 +1126,7 @@ final class Table implements Element
             $current = '';
             foreach ($words as $word) {
                 $candidate = $current === '' ? $word : "$current $word";
-                if ($this->measureWidth($candidate, $baseFontName, $size) <= $maxWidth) {
+                if ($this->measureWidth($candidate, $fontName, $baseFontName, $size) <= $maxWidth) {
                     $current = $candidate;
                 } else {
                     if ($current !== '') {
@@ -1132,11 +1142,27 @@ final class Table implements Element
         return $lines ?: [''];
     }
 
-    private function measureWidth(string $text, string $baseFontName, float $size): float
+    /**
+     * Measure the advance width of $text in points.
+     *
+     * Preference order:
+     *   1. Real glyph metrics from the registered {@see \Papier\Font\Font}
+     *      resolved via $fontName (handles embedded TrueType/OTF correctly,
+     *      including '€', accented Latin and the NBSP inserted by NumberFormatter).
+     *   2. Standard-14 AFM metrics when $baseFontName names a standard font.
+     *   3. Heuristic fallback — but on the Windows-1252 byte form actually
+     *      rendered, so multi-byte UTF-8 glyphs are not over-counted.
+     */
+    private function measureWidth(string $text, string $fontName, string $baseFontName, float $size): float
     {
+        $font = $this->renderResources?->getFontMetrics($fontName);
+        if ($font !== null) {
+            return $font->stringWidth($text, $size);
+        }
         if ($baseFontName !== '' && StandardFonts::isStandard($baseFontName)) {
             return StandardFonts::stringWidth($text, $baseFontName, $size);
         }
-        return strlen($text) * $size * 0.55;
+        $encoded = \Papier\Font\Encoding\WinAnsiEncoding::fromUtf8($text);
+        return strlen($encoded) * $size * 0.55;
     }
 }

--- a/src/Font/Encoding/WinAnsiEncoding.php
+++ b/src/Font/Encoding/WinAnsiEncoding.php
@@ -85,6 +85,22 @@ final class WinAnsiEncoding extends Encoding
         123 => 'braceleft', 124 => 'bar', 125 => 'braceright', 126 => 'asciitilde',
     ];
 
+    /**
+     * Convert a PHP UTF-8 string to its WinAnsiEncoding (Windows-1252) byte
+     * sequence — the exact bytes that simple Type 1 / TrueType fonts in this
+     * library emit to the content stream.
+     *
+     * This is the single source of truth shared by content-stream output
+     * ({@see \Papier\Content\ContentStream::pdfString()}) and width measurement
+     * ({@see \Papier\Font\Font::stringWidth()}), so the bytes measured for
+     * alignment always match the bytes actually drawn.  Characters outside
+     * Windows-1252 (e.g. CJK, the narrow no-break space) become '?'.
+     */
+    public static function fromUtf8(string $s): string
+    {
+        return mb_convert_encoding($s, 'Windows-1252', 'UTF-8');
+    }
+
     public function getName(): string { return 'WinAnsiEncoding'; }
 
     public function getGlyphName(int $charCode): ?string

--- a/src/Font/StandardFonts.php
+++ b/src/Font/StandardFonts.php
@@ -104,10 +104,14 @@ final class StandardFonts
      */
     public static function stringWidth(string $text, string $fontName, float $fontSize): float
     {
-        $width = 0;
-        $len   = strlen($text);
+        // Standard fonts are rendered with WinAnsiEncoding; measure the
+        // Windows-1252 bytes that will be drawn (so '€', accented Latin, etc.
+        // count as one glyph each, matching ContentStream output).
+        $encoded = \Papier\Font\Encoding\WinAnsiEncoding::fromUtf8($text);
+        $width   = 0;
+        $len     = strlen($encoded);
         for ($i = 0; $i < $len; $i++) {
-            $width += self::getGlyphWidth($fontName, ord($text[$i]));
+            $width += self::getGlyphWidth($fontName, ord($encoded[$i]));
         }
         return $width * $fontSize / 1000;
     }

--- a/src/Font/TrueTypeFont.php
+++ b/src/Font/TrueTypeFont.php
@@ -164,10 +164,15 @@ final class TrueTypeFont extends Font
 
     public function stringWidth(string $text, float $size): float
     {
-        $width = 0;
-        $len   = strlen($text);
+        // Measure the same bytes that will be drawn: this font is rendered with
+        // WinAnsiEncoding, so the content stream emits the Windows-1252 form of
+        // the UTF-8 input. Measuring the raw UTF-8 bytes would over-count every
+        // multi-byte glyph (e.g. '€' is 3 UTF-8 bytes but one Windows-1252 byte).
+        $encoded = WinAnsiEncoding::fromUtf8($text);
+        $width   = 0;
+        $len     = strlen($encoded);
         for ($i = 0; $i < $len; $i++) {
-            $code  = ord($text[$i]);
+            $code  = ord($encoded[$i]);
             $width += $this->glyphWidths[$code] ?? 500;
         }
         return $width * $size / 1000;

--- a/src/PdfDocument.php
+++ b/src/PdfDocument.php
@@ -179,6 +179,7 @@ final class PdfDocument
     public function addPage(float $width = 595.28, float $height = 841.89): PdfPage
     {
         $page = new PdfPage($width, $height);
+        $this->attachFontMetrics($page);
         $this->writer->addPage($page);
         return $page;
     }
@@ -190,8 +191,21 @@ final class PdfDocument
      */
     public function appendPage(PdfPage $page): static
     {
+        $this->attachFontMetrics($page);
         $this->writer->addPage($page);
         return $this;
+    }
+
+    /**
+     * Give the page's resources a live resolver from font resource names to the
+     * registered {@see Font} metrics objects, so elements can measure text using
+     * real glyph advance widths (matching what is rendered).
+     */
+    private function attachFontMetrics(PdfPage $page): void
+    {
+        $page->getResources()->setFontMetricsResolver(
+            fn (string $name): ?Font => $this->writer->getFontMetrics($name)
+        );
     }
 
     /**
@@ -240,6 +254,7 @@ final class PdfDocument
             $imported->getWidth()  * $scale,
             $imported->getHeight() * $scale,
         );
+        $this->attachFontMetrics($page);
 
         $name = $imported->getResourceName();
         $page->getResources()->addXObject($name, $imported->getFormXObject());

--- a/src/Structure/PdfResources.php
+++ b/src/Structure/PdfResources.php
@@ -32,6 +32,16 @@ final class PdfResources
     private PdfDictionary $properties;
     private ?PdfArray     $procSet = null;
 
+    /**
+     * Resolver from font resource name (e.g. `F1`) to the {@see \Papier\Font\Font}
+     * object that holds glyph metrics.  Set by {@see \Papier\PdfDocument} so that
+     * elements (notably {@see \Papier\Elements\Table}) can measure text with the
+     * real advance widths of embedded fonts instead of a heuristic.
+     *
+     * @var (\Closure(string): ?\Papier\Font\Font)|null
+     */
+    private ?\Closure $fontMetricsResolver = null;
+
     public function __construct()
     {
         $this->font       = new PdfDictionary();
@@ -61,6 +71,29 @@ final class PdfResources
     public function getFonts(): PdfDictionary
     {
         return $this->font;
+    }
+
+    /**
+     * Install a resolver mapping a font resource name to its {@see \Papier\Font\Font}
+     * metrics object.  Used internally by {@see \Papier\PdfDocument}.
+     *
+     * @param \Closure(string): ?\Papier\Font\Font $resolver
+     */
+    public function setFontMetricsResolver(\Closure $resolver): static
+    {
+        $this->fontMetricsResolver = $resolver;
+        return $this;
+    }
+
+    /**
+     * Resolve the {@see \Papier\Font\Font} metrics object for a font resource
+     * name, or null if no resolver is installed or the name is unknown.
+     */
+    public function getFontMetrics(string $name): ?\Papier\Font\Font
+    {
+        return $this->fontMetricsResolver !== null
+            ? ($this->fontMetricsResolver)($name)
+            : null;
     }
 
     // ── XObjects ──────────────────────────────────────────────────────────────

--- a/src/Writer/PdfWriter.php
+++ b/src/Writer/PdfWriter.php
@@ -177,6 +177,15 @@ final class PdfWriter
         return $name;
     }
 
+    /**
+     * Return the {@see Font} metrics object registered under a resource name,
+     * or null if the name is unknown.  Used for render-time text measurement.
+     */
+    public function getFontMetrics(string $name): ?Font
+    {
+        return $this->fontRegistry[$name]['font'] ?? null;
+    }
+
     // ── PDF generation ────────────────────────────────────────────────────────
 
     /**


### PR DESCRIPTION
Fixes #2.

## Problem

In a right-aligned table column, values containing the `€` glyph, the non-breaking space that `NumberFormatter` inserts, negative numbers, or bold text gained extra right-hand padding.

Right-alignment positions text at `innerWidth − measuredLineWidth`, so an **over-measured** string is pushed left. `Table::measureWidth()` estimated width as `strlen($text) * $size * 0.55` — counting **raw UTF-8 bytes** with a flat per-character average — while the text is actually rendered after a UTF-8 → Windows-1252 conversion (`ContentStream::pdfString()`). So a 3-byte `€` was measured as three glyphs (big padding), and the `0.55` average mismatched real minus/bold metrics (slight padding).

## Fix

**Render-consistent measurement**
- New `WinAnsiEncoding::fromUtf8()` — the single UTF-8 → Windows-1252 converter, now shared by content-stream output and all width measurement, so measured bytes == drawn bytes.
- `TrueTypeFont::stringWidth()` sums real `hmtx` glyph advances over the rendered bytes; `StandardFonts::stringWidth()` and `ContentStream::pdfString()` use the same converter.

**Table uses real font metrics**
- `PdfWriter::getFontMetrics()` exposes registered `Font` objects; `PdfResources` carries a live name→`Font` resolver, wired into every page by `PdfDocument`.
- `Table::measureWidth()` prefers the embedded font's real advance widths, falling back to Standard-14 AFM, then a Windows-1252-aware heuristic.

**Reproduction**
- `examples/16_table_utf8_alignment.php` reproduces the reporter's 4-column right-aligned layout (de_DE `NumberFormatter` currency, negatives, bold total) and prints a before/after measurement comparison.

## Verification

- `"1.234,56 €"` at 9 pt: **64.35 pt → 42.09 pt** (13 UTF-8 bytes vs 10 rendered glyphs); the ~22 pt over-estimate is eliminated.
- Rendering the right column, all four values (incl. negatives and `€`/NBSP) land at exactly **338.00 pt** — the cell right edge minus padding.
- Examples 14 and 15 regenerate cleanly (repo has no unit-test suite, so examples are the verification path).

## Known limitation (separate follow-up)

Simple TrueType + WinAnsi fonts can only represent Windows-1252; characters outside it (CJK, the narrow NBSP U+202F, the typographic minus U+2212) still render as `?` — and now measure consistently as `?`. Full Unicode would require wiring the dormant `Type0Font`/`CIDFont` path into `addFont()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)